### PR TITLE
feat: add context-manager dunder methods to `MultiTransact`

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ except:
 
 tx.run('?[a] <- [[2]] :put a {a}')
 tx.run('?[a] <- [[3]] :put a {a}')
-tx.commit()  # `tx.abort()` abandons the changes so far
+tx.commit()  # `tx.abort()` abandons the changes so far 
 # and deletes resources associated with the transaction.
 
 r = client.run('?[a] := *a[a]')
@@ -156,7 +156,6 @@ You **must** run either `tx.commit()` or `tx.abort()` at the end, otherwise
 you will have a resource leak.
 
 To automatically clean up transactions, the return value of `client.multi-transact` can be used as a context-manager which automatically aborts the transaction at the end of the context if it has not already been committed.
-
 ```python
 with client.multi_transact(True) as tx:
     tx.run(':create a {a})
@@ -173,7 +172,7 @@ You can register functions to run whenever mutations are made against stored rel
 def cb(op_name, new_rows, old_rows):
     # op_name is 'Put' or 'Rm'
     # new_rows is a list of lists containing the new rows (i.e., requested puts or deletes)
-    # old_rows is a list of lists containing the changed rows (i.e., the old rows in the case of puts,
+    # old_rows is a list of lists containing the changed rows (i.e., the old rows in the case of puts, 
     # or the rows actually deleted in the case of deletes)
     pass
 
@@ -265,14 +264,14 @@ For how to determine the `<AUTH_STRING>`, see [here](https://github.com/cozodb/c
 
 There are other magic commands you can use:
 
-- `%cozo_run_file <PATH_TO_FILE>` runs a local file as CozoScript.
-- `%cozo_run_string <VARIABLE>` runs variable containing string as CozoScript.
-- `%cozo_set <KEY> <VALUE>` sets a parameter with the name `<KEY>` to the expression `<VALUE>`. The updated parameters will
+* `%cozo_run_file <PATH_TO_FILE>` runs a local file as CozoScript.
+* `%cozo_run_string <VARIABLE>` runs variable containing string as CozoScript.
+* `%cozo_set <KEY> <VALUE>` sets a parameter with the name `<KEY>` to the expression `<VALUE>`. The updated parameters will
   be used by subsequent queries.
-- `%cozo_set_params <PARAM_MAP>` replace all parameters by the given expression, which must evaluate to a dictionary
+* `%cozo_set_params <PARAM_MAP>` replace all parameters by the given expression, which must evaluate to a dictionary
   with string keys.
-- `%cozo_clear` clears all set parameters.
-- `%cozo_params` returns the parameters currently set.
+* `%cozo_clear` clears all set parameters.
+* `%cozo_params` returns the parameters currently set.
 
 ## Programmatically constructing queries
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ except:
 
 tx.run('?[a] <- [[2]] :put a {a}')
 tx.run('?[a] <- [[3]] :put a {a}')
-tx.commit()  # `tx.abort()` abandons the changes so far 
+tx.commit()  # `tx.abort()` abandons the changes so far
 # and deletes resources associated with the transaction.
 
 r = client.run('?[a] := *a[a]')
@@ -154,6 +154,15 @@ assert r['rows'] == [[1], [2], [3]]
 
 You **must** run either `tx.commit()` or `tx.abort()` at the end, otherwise
 you will have a resource leak.
+
+To automatically clean up transactions, the return value of `client.multi-transact` can be used as a context-manager which automatically aborts the transaction at the end of the context if it has not already been committed.
+
+```python
+with client.multi_transact(True) as tx:
+    tx.run(':create a {a})
+    tx.run('?[a] <- [[1]] :put a {a}')
+    tx.commit()
+```
 
 ### Mutation callbacks
 
@@ -164,7 +173,7 @@ You can register functions to run whenever mutations are made against stored rel
 def cb(op_name, new_rows, old_rows):
     # op_name is 'Put' or 'Rm'
     # new_rows is a list of lists containing the new rows (i.e., requested puts or deletes)
-    # old_rows is a list of lists containing the changed rows (i.e., the old rows in the case of puts, 
+    # old_rows is a list of lists containing the changed rows (i.e., the old rows in the case of puts,
     # or the rows actually deleted in the case of deletes)
     pass
 
@@ -256,14 +265,14 @@ For how to determine the `<AUTH_STRING>`, see [here](https://github.com/cozodb/c
 
 There are other magic commands you can use:
 
-* `%cozo_run_file <PATH_TO_FILE>` runs a local file as CozoScript.
-* `%cozo_run_string <VARIABLE>` runs variable containing string as CozoScript.
-* `%cozo_set <KEY> <VALUE>` sets a parameter with the name `<KEY>` to the expression `<VALUE>`. The updated parameters will
+- `%cozo_run_file <PATH_TO_FILE>` runs a local file as CozoScript.
+- `%cozo_run_string <VARIABLE>` runs variable containing string as CozoScript.
+- `%cozo_set <KEY> <VALUE>` sets a parameter with the name `<KEY>` to the expression `<VALUE>`. The updated parameters will
   be used by subsequent queries.
-* `%cozo_set_params <PARAM_MAP>` replace all parameters by the given expression, which must evaluate to a dictionary
+- `%cozo_set_params <PARAM_MAP>` replace all parameters by the given expression, which must evaluate to a dictionary
   with string keys.
-* `%cozo_clear` clears all set parameters.
-* `%cozo_params` returns the parameters currently set.
+- `%cozo_clear` clears all set parameters.
+- `%cozo_params` returns the parameters currently set.
 
 ## Programmatically constructing queries
 

--- a/pycozo/client.py
+++ b/pycozo/client.py
@@ -16,7 +16,7 @@ class Client:
     This client can either operate on an embedded database, or a remote database via HTTP.
     """
 
-    def __init__(self, engine="mem", path="", options=None, *, dataframe=True):
+    def __init__(self, engine='mem', path='', options=None, *, dataframe=True):
         """Constructor for the client. The behaviour depends on the argument.
 
         If the database `db` is an embedded one, and you do not intend it to live as long as your program, you **must**
@@ -36,26 +36,22 @@ class Client:
                           must be installed.
         """
         self.pandas = None
-        if engine == "http":
-            self.host = options["host"]
-            self.auth = options.get("auth")
+        if engine == 'http':
+            self.host = options['host']
+            self.auth = options.get('auth')
             self.embedded = None
             self._remote_sse = {}
             self._remote_cb_id = 0
         else:
             from cozo_embedded import CozoDbPy
-
             self.embedded = CozoDbPy(engine, path, json.dumps(options or {}))
 
         if dataframe:
             try:
                 import pandas
-
                 self.pandas = pandas
             except ImportError:
-                logger.exception(
-                    "`pandas` feature was requested, but pandas is not installed"
-                )
+                logger.exception('`pandas` feature was requested, but pandas is not installed')
                 pass
 
     def close(self):
@@ -70,25 +66,27 @@ class Client:
             self.embedded.close()
 
     def _headers(self):
-        return {"x-cozo-auth": self.auth}
+        return {
+            'x-cozo-auth': self.auth
+        }
 
     def _client_request(self, script, params=None, immutable=False):
         import requests
 
-        r = requests.post(
-            f"{self.host}/text-query",
-            headers=self._headers(),
-            json={"script": script, "params": params or {}, "immutable": immutable},
-        )
+        r = requests.post(f'{self.host}/text-query', headers=self._headers(), json={
+            'script': script,
+            'params': params or {},
+            'immutable': immutable
+        })
         res = r.json()
         return self._format_return(res)
 
     def _format_return(self, res):
-        if not res["ok"]:
+        if not res['ok']:
             raise QueryException(res)
 
         if self.pandas:
-            return self.pandas.DataFrame(columns=res["headers"], data=res["rows"])
+            return self.pandas.DataFrame(columns=res['headers'], data=res['rows'])
         else:
             return res
 
@@ -98,7 +96,7 @@ class Client:
         except Exception as e:
             raise QueryException(e.args[0]) from None
         if self.pandas:
-            return self.pandas.DataFrame(columns=res["headers"], data=res["rows"])
+            return self.pandas.DataFrame(columns=res['headers'], data=res['rows'])
         else:
             return res
 
@@ -126,15 +124,15 @@ class Client:
             import requests
             import urllib.parse
 
-            rels = ",".join(map(lambda s: urllib.parse.quote_plus(s), relations))
-            url = f"{self.host}/export/{rels}"
+            rels = ','.join(map(lambda s: urllib.parse.quote_plus(s), relations))
+            url = f'{self.host}/export/{rels}'
 
             r = requests.get(url, headers=self._headers())
             res = r.json()
-            if res["ok"]:
-                return res["data"]
+            if res['ok']:
+                return res['data']
             else:
-                raise RuntimeError(res["message"])
+                raise RuntimeError(res['message'])
 
     def import_relations(self, data):
         """Import data into a database
@@ -149,13 +147,12 @@ class Client:
             self.embedded.import_relations(data)
         else:
             import requests
-
-            url = f"{self.host}/import"
+            url = f'{self.host}/import'
 
             r = requests.put(url, headers=self._headers(), json=data)
             res = r.json()
-            if not res["ok"]:
-                raise RuntimeError(res["message"])
+            if not res['ok']:
+                raise RuntimeError(res['message'])
 
     def backup(self, path):
         """Backup a database to the specified path.
@@ -167,12 +164,10 @@ class Client:
         else:
             import requests
 
-            r = requests.post(
-                f"{self.host}/backup", headers=self._headers(), json={"path": path}
-            )
+            r = requests.post(f'{self.host}/backup', headers=self._headers(), json={'path': path})
             res = r.json()
-            if not res["ok"]:
-                raise RuntimeError(res["message"])
+            if not res['ok']:
+                raise RuntimeError(res['message'])
 
     def register_callback(self, relation, callback):
         if self.embedded:
@@ -182,20 +177,17 @@ class Client:
 
             tid = self._remote_cb_id
             self._remote_cb_id += 1
-            url = f"{self.host}/changes/{relation}"
-            thread = threading.Thread(
-                target=self._start_sse, args=(tid, url, callback), daemon=True
-            )
+            url = f'{self.host}/changes/{relation}'
+            thread = threading.Thread(target=self._start_sse, args=(tid, url, callback), daemon=True)
             thread.start()
-            self._remote_sse[tid] = {"thread": thread}
+            self._remote_sse[tid] = {'thread': thread}
 
             return tid
 
     def _start_sse(self, tid, url, callback, min_delay=1, max_delay=60):
         import requests
-
-        logger.info("Starting SSE thread")
-        headers = {"Accept": "text/event-stream", "Accept-Encoding": ""}
+        logger.info('Starting SSE thread')
+        headers = {'Accept': 'text/event-stream', 'Accept-Encoding': ''}
 
         consecutive_failures = 0
 
@@ -209,31 +201,25 @@ class Client:
                     buffer = b""
                     for chunk in response.iter_content(chunk_size=1):
                         if tid not in self._remote_sse:
-                            logger.info("Stopping SSE thread")
+                            logger.info('Stopping SSE thread')
                             return
                         buffer += chunk
-                        if buffer.endswith(b"\n\n"):
-                            event_text = buffer.decode("utf-8").strip()
-                            if event_text.startswith("data:"):
+                        if buffer.endswith(b'\n\n'):
+                            event_text = buffer.decode('utf-8').strip()
+                            if event_text.startswith('data:'):
                                 payload = json.loads(event_text[5:].strip())
-                                callback(
-                                    payload["op"],
-                                    payload["new_rows"]["rows"],
-                                    payload["old_rows"]["rows"],
-                                )
+                                callback(payload['op'], payload['new_rows']['rows'], payload['old_rows']['rows'])
                             buffer = b""
             except Exception as e:
                 import time
 
-                logger.error(f"Error in SSE thread: {e}")
+                logger.error(f'Error in SSE thread: {e}')
                 consecutive_failures += 1
 
                 # Exponential backoff with a cap at max_delay
-                backoff_delay = min(
-                    min_delay * (2 ** (consecutive_failures - 1)), max_delay
-                )
+                backoff_delay = min(min_delay * (2 ** (consecutive_failures - 1)), max_delay)
 
-                logger.info(f"Sleeping for {backoff_delay} seconds before retrying...")
+                logger.info(f'Sleeping for {backoff_delay} seconds before retrying...')
                 time.sleep(backoff_delay)
 
     def unregister_callback(self, cb_id):
@@ -246,13 +232,13 @@ class Client:
         if self.embedded:
             return self.embedded.register_fixed_rule(name, arity, impl)
         else:
-            raise RuntimeError("Only supported on embedded DBs")
+            raise RuntimeError('Only supported on embedded DBs')
 
     def unregister_fixed_rule(self, name):
         if self.embedded:
             return self.embedded.unregister_fixed_rule(name)
         else:
-            raise RuntimeError("Only supported on embedded DBs")
+            raise RuntimeError('Only supported on embedded DBs')
 
     def restore(self, path):
         """Restore database from a backup. Must be called on an empty database.
@@ -263,7 +249,7 @@ class Client:
         if self.embedded:
             self.embedded.restore(path)
         else:
-            raise RuntimeError("Remote databases cannot be restored remotely")
+            raise RuntimeError('Remote databases cannot be restored remotely')
 
     def import_from_backup(self, path, relations):
         """Import stored relations from a backup.
@@ -280,20 +266,17 @@ class Client:
         else:
             import requests
 
-            r = requests.post(
-                f"{self.host}/import-from-backup",
-                headers=self._headers(),
-                json={"path": path, "relations": relations},
-            )
+            r = requests.post(f'{self.host}/import-from-backup', headers=self._headers(),
+                              json={'path': path, 'relations': relations})
             res = r.json()
-            if not res["ok"]:
-                raise RuntimeError(res["message"])
+            if not res['ok']:
+                raise RuntimeError(res['message'])
 
     def multi_transact(self, write=False):
         if self.embedded:
             return MultiTransact(self.embedded.multi_transact(write))
         else:
-            raise RuntimeError("Multi-transaction not yet supported for remote")
+            raise RuntimeError('Multi-transaction not yet supported for remote')
 
     def _process_mutate_data_dict(self, data):
         cols = []
@@ -306,7 +289,7 @@ class Client:
     def _process_mutate_data(self, data):
         if isinstance(data, dict):
             cols, row = self._process_mutate_data_dict(data)
-            return ",".join(cols), [row]
+            return ','.join(cols), [row]
         elif isinstance(data, list):
             cols, row = self._process_mutate_data_dict(data[0])
             rows = [row]
@@ -315,33 +298,32 @@ class Client:
                 for col in cols:
                     nxt_row.append(el[col])
                 rows.append(nxt_row)
-            return ",".join(cols), rows
+            return ','.join(cols), rows
         else:
             import pandas as pd
-
             if isinstance(data, pd.DataFrame):
                 cols = data.columns.tolist()
                 rows = data.values.tolist()
-                return ",".join(cols), rows
+                return ','.join(cols), rows
             else:
-                raise RuntimeError("Invalid data type for mutation")
+                raise RuntimeError('Invalid data type for mutation')
 
     def _mutate(self, relation, data, op):
         cols_str, processed_data = self._process_mutate_data(data)
-        q = f"?[{cols_str}] <- $data :{op} {relation} {{ {cols_str} }}"
-        return self.run(q, {"data": processed_data})
+        q = f'?[{cols_str}] <- $data :{op} {relation} {{ {cols_str} }}'
+        return self.run(q, {'data': processed_data})
 
     def insert(self, relation, data):
-        return self._mutate(relation, data, "insert")
+        return self._mutate(relation, data, 'insert')
 
     def put(self, relation, data):
-        return self._mutate(relation, data, "put")
+        return self._mutate(relation, data, 'put')
 
     def update(self, relation, data):
-        return self._mutate(relation, data, "update")
+        return self._mutate(relation, data, 'update')
 
     def rm(self, relation, data):
-        return self._mutate(relation, data, "rm")
+        return self._mutate(relation, data, 'rm')
 
 
 class MultiTransact:
@@ -368,26 +350,25 @@ class MultiTransact:
 
 
 class QueryException(Exception):
-    """The exception class for queries. `repr(e)` will pretty format the exceptions into ANSI-coloured messages."""
+    """The exception class for queries. `repr(e)` will pretty format the exceptions into ANSI-coloured messages.
+    """
 
     def __init__(self, resp):
         super().__init__()
         self.resp = resp
 
     def __repr__(self):
-        if hasattr(self.resp, "get"):
-            return (
-                self.resp.get("display") or self.resp.get("message") or str(self.resp)
-            )
+        if hasattr(self.resp, 'get'):
+            return self.resp.get('display') or self.resp.get('message') or str(self.resp)
         else:
             return str(self.resp)
 
     def __str__(self):
-        return self.resp.get("message") or str(self.resp)
+        return self.resp.get('message') or str(self.resp)
 
     def _repr_pretty_(self, p, cycle):
         p.text(repr(self))
 
     @property
     def code(self):
-        return self.resp.get("code")
+        return self.resp.get('code')


### PR DESCRIPTION
This adds the `__enter__` and `__exit__` methods to the `MultiTransact` class in `client.py`, so that `MultiTransact` instances can be used with the `with` construct. The `__exit__` method, which is used to clean-up resources, is presently implemented by trying to abort the transaction. I am presuming that if the transaction has already been committed, then attempting to abort with raise a runtime error and will not change any state in the db. I'd consider a solution in which I was able to check the state of the transaction from python to be more elegant, but I didn't see such an API available. For another PR, perhaps.

This also updates the README to document the usage of multi-transactions as a context-manager.